### PR TITLE
Filtering duplicates

### DIFF
--- a/server.js
+++ b/server.js
@@ -120,10 +120,12 @@ const getNotifications = (ops) => {
         /** Find mentions */
         const pattern = /(@[a-z][-\.a-z\d]+[a-z\d])/gi;
         const content = `${params.title} ${params.body}`;
-        const mentions = _.without(_.uniq(content.match(pattern))
-          .join('@')
-          .toLowerCase()
-          .split('@')
+        const mentions = _.without(
+          _.uniq((content.match(pattern) || [])
+            .join('@')
+            .toLowerCase()
+            .split('@')
+          )
           .filter(n => n), params.author)
           .slice(0, 9); // Handle maximum 10 mentions per post
         if (mentions.length) {


### PR DESCRIPTION
the _.uniq method should be applied after the join -> lowercase -> split sequence
otherwise if a post contains @user and @ User the resulting array will contain ['user','user']