### PR TITLE
feat: don't send notifications of actions on own posts busyorg/busy/#1605

### DIFF
--- a/server.js
+++ b/server.js
@@ -126,7 +126,7 @@ const getNotifications = ops => {
         const isRootPost = !params.parent_author;
 
         /** Find replies */
-        if (!isRootPost) {
+        if (!isRootPost && params.parent_author !== params.author) {
           const notification = {
             type: 'reply',
             parent_permlink: params.parent_permlink,
@@ -213,6 +213,9 @@ const getNotifications = ops => {
       }
       case 'account_witness_vote': {
         /** Find witness vote */
+        if (params.account === params.witness) {
+          break;
+        }
         const notification = {
           type: 'witness_vote',
           account: params.account,
@@ -226,6 +229,7 @@ const getNotifications = ops => {
       }
       case 'vote': {
         /** Find downvote */
+        // notification of downvoting self can be useful, so let it be
         if (params.weight < 0) {
           const notification = {
             type: 'vote',


### PR DESCRIPTION
Fixes busyorg/busy/#1605

I left notification of disliking own reply, because it can be useful.

### Changes
* disallows pushing reply notifications to redis
* disallows pushing notification when voting on self in a witness vote

### Test plan
* [ ] Post a comment under own post
* [ ] Post a comment under own comment